### PR TITLE
Switch to beartype to accommodate pep-585 and increment version to 0.0.2 to simplify dependency-handling

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,7 @@ matplotlib
 
 tensorflow
 tensorflow-probability
+tf-keras
 
 black
 flake8

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
 
 setup(
     name="Spherical Harmonics",
-    version="0.0.1",
+    version="0.0.2",
     author="vd309@cam.ac.uk",
     description="Python Implementation of Spherical harmonics in dimension >= 3",
     packages=find_packages("src"),  # include all packages under src

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
 
 setup(
     name="Spherical Harmonics",
-    version="0.0.2",
+    version="0.0.2a0",
     author="vd309@cam.ac.uk",
     description="Python Implementation of Spherical harmonics in dimension >= 3",
     packages=find_packages("src"),  # include all packages under src

--- a/src/spherical_harmonics/fundamental_set.py
+++ b/src/spherical_harmonics/fundamental_set.py
@@ -189,7 +189,6 @@ def calculate_decrement_in_determinant(Z, X_system, M_system_chol, gegenbauer):
 
 
 def grad_calculate_decrement_in_determinant(Z, X_system, M_system_chol, gegenbauer):
-
     r"""Calculate the negative determinant.
 
     :param Z: is a potential vector for the next fundamental point (it will get normalized)

--- a/src/spherical_harmonics/gegenbauer_polynomial.py
+++ b/src/spherical_harmonics/gegenbauer_polynomial.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import math
-from typing import List, Tuple, Union
 
 import lab as B
 import numpy as np
+from beartype.typing import List, Tuple, Union
 from scipy.special import gegenbauer as scipy_gegenbauer
 from scipy.special import loggamma
 

--- a/src/spherical_harmonics/lab_extras/extras.py
+++ b/src/spherical_harmonics/lab_extras/extras.py
@@ -1,6 +1,5 @@
-from typing import List
-
 import lab as B
+from beartype.typing import List
 from lab import dispatch
 from lab.util import abstract
 from plum import Union

--- a/src/spherical_harmonics/lab_extras/jax/extras.py
+++ b/src/spherical_harmonics/lab_extras/jax/extras.py
@@ -1,7 +1,6 @@
-from typing import List
-
 import jax.numpy as jnp
 import lab as B
+from beartype.typing import List
 from lab import dispatch
 from plum import Union
 

--- a/src/spherical_harmonics/lab_extras/numpy/extras.py
+++ b/src/spherical_harmonics/lab_extras/numpy/extras.py
@@ -1,7 +1,6 @@
-from typing import List
-
 import lab as B
 import numpy as np
+from beartype.typing import List
 from lab import dispatch
 from plum import Union
 

--- a/src/spherical_harmonics/lab_extras/tensorflow/extras.py
+++ b/src/spherical_harmonics/lab_extras/tensorflow/extras.py
@@ -1,7 +1,6 @@
-from typing import List
-
 import lab as B
 import tensorflow as tf
+from beartype.typing import List
 from lab import dispatch
 from plum import Union
 

--- a/src/spherical_harmonics/lab_extras/torch/extras.py
+++ b/src/spherical_harmonics/lab_extras/torch/extras.py
@@ -1,7 +1,6 @@
-from typing import List
-
 import lab as B
 import torch
+from beartype.typing import List
 from lab import dispatch
 from plum import Union
 

--- a/src/spherical_harmonics/plotting.py
+++ b/src/spherical_harmonics/plotting.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
-
 import matplotlib.pyplot as plt
 import numpy as np
 import plotly.graph_objects as go
+from beartype.typing import Callable
 from matplotlib import cm
 
 

--- a/src/spherical_harmonics/plotting.py
+++ b/src/spherical_harmonics/plotting.py
@@ -61,6 +61,7 @@ def plot_spherical_function(
     # scale the colors
     fmax, fmin = fgrid.max(), fgrid.min()
     fcolors = (fgrid - fmin) / (fmax - fmin)
+    viridis = cm.get_cmap("viridis")
 
     ax.plot_surface(
         grid[:, 0].reshape(resolution, resolution) * scale,
@@ -68,7 +69,7 @@ def plot_spherical_function(
         grid[:, 2].reshape(resolution, resolution) * scale,
         rstride=1,
         cstride=1,
-        facecolors=cm.viridis(fcolors),
+        facecolors=viridis(fcolors),
     )
 
     # Turn off the axis planes

--- a/src/spherical_harmonics/spherical_harmonics.py
+++ b/src/spherical_harmonics/spherical_harmonics.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 """ Spherical Harmonics and associated utility functions """
-from typing import List, Union
 
 import lab as B
 import numpy as np
+from beartype.typing import List, Union
 from scipy.special import gegenbauer as scipy_gegenbauer
 
 from spherical_harmonics.fundamental_set import FundamentalSystemCache, num_harmonics

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -27,7 +27,11 @@ def spherical_function_to_plot():
     return func
 
 
-@pytest.mark.parametrize("use_mesh", [True, False])
+# FIXME: the use_mesh=True test is commented out because it relies on meshzoo
+# which now requires a paid license. This could be fixed by using, e.g.,
+# potpourri3d instead of meshzoo.
+# @pytest.mark.parametrize("use_mesh", [True, False])
+@pytest.mark.parametrize("use_mesh", [False])
 @pytest.mark.parametrize("animate_steps", [0, 11])
 def test_plotting(spherical_function_to_plot, use_mesh, animate_steps):
     _ = plotly_plot_spherical_function(


### PR DESCRIPTION
Motivation: it was giving the following warning in [GeometricKernels](https://github.com/GPflow/GeometricKernels/pull/107).
```python
BeartypeDecorHintPep585DeprecationWarning: PEP 484 type hint typing.List deprecated by PEP 585. This hint is scheduled for removal in the first Python version released after October 5th, 2025. To resolve this, import this hint from "beartype.typing" rather than "typing". For further commentary and alternatives, see also:
    https://beartype.readthedocs.io/en/latest/api_roar/#pep-585-deprecations
```

This PR also fixes some `make check-and-test` complaints connected to newer versions of dependencies.