### PR TITLE
Modernize

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
 
     name: Python-${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ format: ## Formats code with `black` and `isort`
 
 check: ## Runs all static checks such as code formatting checks, linting, mypy
 	@echo "\n=== flake8 (linting)===================================="
-	flake8 --statistics --exclude=.ipynb_checkpoints
+	flake8 --statistics --exclude=.ipynb_checkpoints,.venv
 	@echo "\n=== black (formatting) ================================="
 	black --check --diff $(LINT_NAMES)
 	@echo "\n=== isort (formatting) ================================="

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,12 @@ authors = [{ name = "Vincent Dutordoir", email = "vd309@cam.ac.uk" }]
 description = "Python Implementation of Spherical harmonics in dimension >= 3"
 readme = "README.md"
 dependencies = [
-    "backends",
+    "backends>=1.8.0",
     "numpy",
+    "plum-dispatch>=2.6.0",
     "scipy",
 ]
-requires-python=">=3.9"
+requires-python=">=3.10"
 
 [project.urls]
 Source = "https://github.com/vdutor/SphericalHarmonics"
@@ -28,7 +29,7 @@ allow_redefinition = true
 
 [tool.black]
 line-length = 88
-target-version = ['py37']
+target-version = ['py310', 'py311', 'py312']
 
 [tool.isort]
 profile = "black"
@@ -37,5 +38,4 @@ skip_glob = [
 ]
 known_third_party = [
      "lab",
-     "plum",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 plotly
 matplotlib
-backends
+backends>=1.8.0
+plum-dispatch>=2.6.0

--- a/src/spherical_harmonics/fundamental_set.py
+++ b/src/spherical_harmonics/fundamental_set.py
@@ -15,7 +15,6 @@
 import argparse
 import importlib.resources
 import warnings
-from typing import Optional
 
 import numpy as np
 from scipy import linalg, optimize
@@ -89,7 +88,7 @@ class FundamentalSystemCache:
         """Return the key used in the cache"""
         return f"degree_{degree}"
 
-    def load(self, degree: int) -> Optional[np.ndarray]:
+    def load(self, degree: int) -> np.ndarray | None:
         """Load or calculate the set for given degree"""
         key = self.cache_key(degree)
         if key not in self.cache:

--- a/src/spherical_harmonics/gegenbauer_polynomial.py
+++ b/src/spherical_harmonics/gegenbauer_polynomial.py
@@ -16,7 +16,6 @@ import math
 
 import lab as B
 import numpy as np
-from beartype.typing import List, Tuple, Union
 from lab import dispatch
 from scipy.special import gegenbauer as scipy_gegenbauer
 from scipy.special import loggamma
@@ -32,8 +31,8 @@ class Polynomial:
 
     def __init__(
         self,
-        coefficients: Union[List, np.ndarray],
-        powers: Union[List, np.ndarray],
+        coefficients: list | np.ndarray,
+        powers: list | np.ndarray,
     ):
         r"""
         The polynomial f(x) is given by f(x) = \sum_i c_i x^{p_i},
@@ -96,7 +95,7 @@ class GegenbauerManualCoefficients(Polynomial):
 
     def _compute_coefficients_and_powers(
         self, n: int, alpha: float
-    ) -> Tuple[List, List]:
+    ) -> tuple[list, list]:
         """
         Compute the weights (coefficients) and powers of the Gegenbauer functions
         expressed as polynomial.

--- a/src/spherical_harmonics/lab_extras/extras.py
+++ b/src/spherical_harmonics/lab_extras/extras.py
@@ -1,8 +1,6 @@
 import lab as B
-from beartype.typing import List
 from lab import dispatch
 from lab.util import abstract
-from plum import Union
 
 
 @dispatch
@@ -21,7 +19,7 @@ def polyval(coeffs: list, x: B.Numeric):
 
 @dispatch
 @abstract()
-def from_numpy(_: B.Numeric, b: Union[list, List, B.Numeric, B.NPNumeric]):
+def from_numpy(_: B.Numeric, b: list | B.Numeric | B.NPNumeric):
     """
     Converts the array `b` to a tensor of the same backend as `a`
     """

--- a/src/spherical_harmonics/lab_extras/jax/extras.py
+++ b/src/spherical_harmonics/lab_extras/jax/extras.py
@@ -1,10 +1,10 @@
+from typing import TypeAlias
+
 import jax.numpy as jnp
 import lab as B
-from beartype.typing import List
 from lab import dispatch
-from plum import Union
 
-_Numeric = Union[B.Number, B.JAXNumeric]
+_Numeric: TypeAlias = B.Number | B.JAXNumeric
 
 
 @dispatch
@@ -22,7 +22,9 @@ def polyval(coeffs: list, x: _Numeric) -> _Numeric:  # type: ignore
 
 
 @dispatch
-def from_numpy(a: B.JAXNumeric, b: Union[list, List, B.NPNumeric, B.Number, B.JAXNumeric]):  # type: ignore
+def from_numpy(
+    a: B.JAXNumeric, b: list | B.NPNumeric | B.Number | B.JAXNumeric
+):  # type: ignore
     """
     Converts the array `b` to a tensor of the same backend as `a`
     """

--- a/src/spherical_harmonics/lab_extras/numpy/extras.py
+++ b/src/spherical_harmonics/lab_extras/numpy/extras.py
@@ -1,10 +1,10 @@
+from typing import TypeAlias
+
 import lab as B
 import numpy as np
-from beartype.typing import List
 from lab import dispatch
-from plum import Union
 
-_Numeric = Union[B.Number, B.NPNumeric]
+_Numeric: TypeAlias = B.Number | B.NPNumeric
 
 
 @dispatch
@@ -22,7 +22,7 @@ def polyval(coeffs: list, x: _Numeric) -> _Numeric:  # type: ignore
 
 
 @dispatch
-def from_numpy(a: B.NPNumeric, b: Union[list, List, B.NPNumeric, B.Number]):  # type: ignore
+def from_numpy(a: B.NPNumeric, b: list | B.NPNumeric | B.Number):  # type: ignore
     """
     Converts the array `b` to a tensor of the same backend as `a`
     """

--- a/src/spherical_harmonics/lab_extras/tensorflow/extras.py
+++ b/src/spherical_harmonics/lab_extras/tensorflow/extras.py
@@ -1,10 +1,10 @@
+from typing import TypeAlias
+
 import lab as B
 import tensorflow as tf
-from beartype.typing import List
 from lab import dispatch
-from plum import Union
 
-_Numeric = Union[B.Number, B.TFNumeric, B.NPNumeric]
+_Numeric: TypeAlias = B.Number | B.TFNumeric | B.NPNumeric
 
 
 @dispatch
@@ -23,7 +23,9 @@ def polyval(coeffs: list, x: _Numeric) -> _Numeric:  # type: ignore
 
 
 @dispatch
-def from_numpy(a: B.TFNumeric, b: Union[list, List, B.Numeric, B.NPNumeric, B.TFNumeric]):  # type: ignore
+def from_numpy(
+    a: B.TFNumeric, b: list | B.Numeric | B.NPNumeric | B.TFNumeric
+):  # type: ignore
     """
     Converts the array `b` to a tensor of the same backend as `a`
     """

--- a/src/spherical_harmonics/lab_extras/torch/extras.py
+++ b/src/spherical_harmonics/lab_extras/torch/extras.py
@@ -1,10 +1,10 @@
+from typing import TypeAlias
+
 import lab as B
 import torch
-from beartype.typing import List
 from lab import dispatch
-from plum import Union
 
-_Numeric = Union[B.Number, B.TorchNumeric]
+_Numeric: TypeAlias = B.Number | B.TorchNumeric
 
 
 @dispatch
@@ -27,7 +27,7 @@ def polyval(coeffs: list, x: _Numeric) -> _Numeric:  # type: ignore
 
 @dispatch
 def from_numpy(
-    a: B.TorchNumeric, b: Union[List, B.Number, B.NPNumeric, B.TorchNumeric]
+    a: B.TorchNumeric, b: list | B.Number | B.NPNumeric | B.TorchNumeric
 ):  # type: ignore
     """
     Converts the array `b` to a tensor of the same backend as `a`

--- a/src/spherical_harmonics/spherical_harmonics.py
+++ b/src/spherical_harmonics/spherical_harmonics.py
@@ -16,7 +16,6 @@
 
 import lab as B
 import numpy as np
-from beartype.typing import List, Union
 from scipy.special import gegenbauer as scipy_gegenbauer
 
 from spherical_harmonics.fundamental_set import FundamentalSystemCache, num_harmonics
@@ -35,7 +34,7 @@ class SphericalHarmonics:
     def __init__(
         self,
         dimension: int,
-        degrees: Union[int, List[int]],
+        degrees: int | list[int],
         debug: bool = False,
         allow_uncomputed_levels: bool = False,
     ):
@@ -223,7 +222,7 @@ class SphericalHarmonicsLevel:
         )  # [N, 1]
         return (self.degree / self.alpha + 1.0) * c  # [N, 1]
 
-    def eigenvalue(self) -> Union[int, float, np.ndarray]:
+    def eigenvalue(self) -> int | float | np.ndarray:
         """
         Spherical harmonics are eigenfunctions of the Laplace-Beltrami operator
         (also known as the Spherical Laplacian). We return the associated
@@ -239,8 +238,8 @@ class SphericalHarmonicsLevel:
 
 
 def eigenvalue_harmonics(
-    degrees: Union[int, float, np.ndarray], dimension: int
-) -> Union[int, float, np.ndarray]:
+    degrees: int | float | np.ndarray, dimension: int
+) -> int | float | np.ndarray:
     """
     Eigenvalue of a spherical harmonic of a specific degree.
 

--- a/tests/test_spherical_harmonics.py
+++ b/tests/test_spherical_harmonics.py
@@ -1,5 +1,3 @@
-from typing import List, Union
-
 import lab as B
 import numpy as np
 import pytest
@@ -165,9 +163,7 @@ class SphericalHarmonics2(SphericalHarmonics):
     the one in `SphericalHarmonicsCollection` as we don't make use of a `map`.
     """
 
-    def __init__(
-        self, dimension: int, degrees: Union[int, List[int]], debug: bool = True
-    ):
+    def __init__(self, dimension: int, degrees: int | list[int], debug: bool = True):
         """
         :param dimension: if d = dimension, then
             S^{d-1} = { x ∈ R^d and ||x||_2 = 1 }


### PR DESCRIPTION
- drop python-3.9
- use native types instead of `typing`
- Update requirements